### PR TITLE
replaced readme backslashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Tip: If you are at liberty to break a suggested file into smaller pieces and re-
 
 ### [Security Policy](docs/SECURITY.md)
 
-### [Bug Reports](.github\ISSUE_TEMPLATE\bug_report.md)
+### [Bug Reports](.github/ISSUE_TEMPLATE/bug_report.md)
 
-### [Feature Requests](.github\ISSUE_TEMPLATE\feature_request.md)
+### [Feature Requests](.github/ISSUE_TEMPLATE/feature_request.md)
 
-### [Pull Requests](.github\pull_request_template.md)
+### [Pull Requests](.github/pull_request_template.md)


### PR DESCRIPTION
## Describe

Fixed the 404s when clicking links from the readme to the `.github` directory files.

## Issue

N/A

## Let Us Know If

- [ ] I'm requesting help with the "Required Checklist"
- [ ] This is incomplete (but hopefully non-breaking)
- [ ] The pre-commit hook was bypassed

### Clarify any of the above

N/A

## Required Checklist

- [X] Each file has only 1 function
- [X] Unit tests cover 100% of conditionals

## Additional

N/A
